### PR TITLE
fix: do not return false in listener for "cn_mail-mailmessagegridload"-event

### DIFF
--- a/src/app/plugin/NewMessagesNotificationPlugin.js
+++ b/src/app/plugin/NewMessagesNotificationPlugin.js
@@ -123,7 +123,7 @@ Ext.define("conjoon.cn_mail.app.plugin.NewMessagesNotificationPlugin", {
      * @param {conjoon.cn_mail.model.mail.folder.MailFolder} mailFolder
      * @param {Array<conjoon.cn_mail.model.mail.message.MessageItem>} messageItems
      *
-     * @return {Boolean} false if no notification as initiated, otherwise true
+     * @return {null|Boolean=true} true if notification process was initiated, otehrwise null
      */
     onNewMessagesAvailable (mailFolder, messageItems) {
 
@@ -132,7 +132,7 @@ Ext.define("conjoon.cn_mail.app.plugin.NewMessagesNotificationPlugin", {
             len = messageItems.length;
 
         if (!len) {
-            return false;
+            return null;
         }
 
         const notificationTxt = me.getNotificationText(mailFolder, len);
@@ -156,8 +156,7 @@ Ext.define("conjoon.cn_mail.app.plugin.NewMessagesNotificationPlugin", {
      * @param {conjoon.cn_mail.store.mail.message.MessageItemStore} store
      * @param {Array<conjoon.cn_mail.model.mail.message.MessageItem>} messageItems
      *
-     * @return {Boolean} false if no messages where available for showing a Notification,
-     * otherwise true
+     * @return {null|Boolean=true} true for notifications that were sent, otherwise null
      */
     onMessageGridLoad (store, messageItems) {
 
@@ -172,7 +171,7 @@ Ext.define("conjoon.cn_mail.app.plugin.NewMessagesNotificationPlugin", {
             );
 
         if (!recentMessages.length) {
-            return false;
+            return null;
         }
 
         recentMessages.forEach(recentMessage => {

--- a/tests/src/app/plugin/NewMessagesNotificationPluginTest.js
+++ b/tests/src/app/plugin/NewMessagesNotificationPluginTest.js
@@ -362,7 +362,7 @@ StartTest(t => {
             messageItems = [record];
 
         conjoon.cn_mail.MailboxService.recentMessageItemKeys.add(record.getCompoundKey().toString());
-        t.expect(plugin.onMessageGridLoad(store, messageItems)).toBe(false);
+        t.expect(plugin.onMessageGridLoad(store, messageItems)).toBe(null);
 
         conjoon.cn_mail.MailboxService.recentMessageItemKeys.clear();
 
@@ -392,7 +392,7 @@ StartTest(t => {
             notificationSpy = t.spyOn(plugin, "showNotification").and.callFake(() => {}),
             updateGridSpy = t.spyOn(plugin, "updateMessageGridWithRecentMessages").and.callFake(() => {});
 
-        t.expect(plugin.onNewMessagesAvailable(mailFolder, [])).toBe(false);
+        t.expect(plugin.onNewMessagesAvailable(mailFolder, [])).toBe(null);
         t.expect(plugin.onNewMessagesAvailable(mailFolder, messageItems)).toBe(true);
 
         t.expect(textSpy.calls.mostRecent().args).toEqual([mailFolder, 1]);


### PR DESCRIPTION
fixed an issue where the "cn_mail-mailmessagegridload"-event would cancel
further events due to NewMessagesNotificationPlugin returning false in
onMessageGridLoad

refs conjoon/extjs-app-webmail#161