### PR TITLE
fix: AttachmentList should show correct icon class for mime type

### DIFF
--- a/classic/src/view/mail/message/AbstractAttachmentList.js
+++ b/classic/src/view/mail/message/AbstractAttachmentList.js
@@ -161,7 +161,7 @@ Ext.define("conjoon.cn_mail.view.mail.message.AbstractAttachmentList", {
             return "fa-file-pdf";
 
         case "text/plain":
-            return  "fa-file-alt";
+            return "fa-file-alt";
 
         case "text/html":
         case "application/json":
@@ -170,11 +170,12 @@ Ext.define("conjoon.cn_mail.view.mail.message.AbstractAttachmentList", {
         case "application/gzip":
         case "application/zip":
         case "application/x-rar-compressed":
+        case "application/x-zip-compressed":
             return "fa-file-archive";
 
         }
 
-        return "fa-file-o";
+        return "fa-file";
     }
 
 

--- a/tests/classic/_issues_/fix/extjs-app-webmail#135.js
+++ b/tests/classic/_issues_/fix/extjs-app-webmail#135.js
@@ -1,0 +1,52 @@
+/**
+ * conjoon
+ * extjs-app-webmail
+ * Copyright (C) 2021 Thorsten Suckow-Homberg https://github.com/conjoon/extjs-app-webmail
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+StartTest(async t => {
+
+    let cmp;
+
+    t.beforeEach(t => {
+        cmp = Ext.create("conjoon.cn_mail.view.mail.message.AbstractAttachmentList");
+    });
+
+    t.afterEach(t => {
+        cmp.destroy();
+        cmp = null;
+    });
+
+    // +-----------------------------------------
+    // | Tests
+    // +-----------------------------------------
+    t.diag("fix: AttachmentList must show icons representing mime types (conjoon/extjs-app-webmail#135)");
+
+    t.it("getMimeTypeIcon()", t => {
+
+        t.expect(cmp.getMimeTypeIcon("unknown")).toBe("fa-file");
+        t.expect(cmp.getMimeTypeIcon("application/x-zip-compressed")).toBe("fa-file-archive");
+
+    });
+
+});

--- a/tests/groups.config.js
+++ b/tests/groups.config.js
@@ -270,6 +270,12 @@ export default [{
                 name: "conjoon/extjs-app-webmail#112",
                 url: "classic/_issues_/feat/extjs-app-webmail%23112.js"
             }]
+        }, {
+            group: "fix",
+            items: [{
+                name: "conjoon/extjs-app-webmail#135",
+                url: "classic/_issues_/fix/extjs-app-webmail%23135.js"
+            }]
         }]
     }, {
         group: "view",


### PR DESCRIPTION
also added mime type "application/x-zip-compressed" to list for "fa-file-archive"

refs conjoon/extjs-app-webmail#135