### PR TITLE
fix: make sure confirm dialog before closing is called properly

### DIFF
--- a/src/data/mail/service/MailboxService.js
+++ b/src/data/mail/service/MailboxService.js
@@ -502,7 +502,8 @@ Ext.define("conjoon.cn_mail.data.mail.service.MailboxService", {
      */
     moveCallback: function (op) {
 
-        const me               = this,
+        const
+            me               = this,
             request          = op.getRequest(),
             sourceFolderId   = request.sourceFolderId,
             targetFolderId   = request.targetFolderId,
@@ -510,17 +511,23 @@ Ext.define("conjoon.cn_mail.data.mail.service.MailboxService", {
             mailAccountId    = record.get("mailAccountId"),
             mailFolderHelper = me.getMailFolderHelper();
 
+        if (op.getResult().success !== true) {
+            return false;
+        }
+
         // just like MessageItemUpdater#updateItemWithDraft, we're setting the
         // messageBodyId here
         // @see conjoon/extjs-app-webmail#116
         record.set("messageBodyId", record.getId());
 
-        if (op.getResult().success !== true) {
-            return false;
+        // we are not interested in tracking the changes made to the mailFolderId
+        // of the MessageBody, so silently commit this here
+        if (record.entityName === "MessageDraft") {
+            record.getMessageBody().commit(true);
         }
 
         if (record.get("seen")) {
-            return;
+            return true;
         }
 
         let sourceFolder = mailFolderHelper.getMailFolder(mailAccountId, sourceFolderId),
@@ -571,7 +578,6 @@ Ext.define("conjoon.cn_mail.data.mail.service.MailboxService", {
         if (mailFolder) {
             mailFolder.set("unreadCount", Math.max(0, mailFolder.get("unreadCount") - 1), {dirty: false});
         }
-
 
         return true;
     }

--- a/src/view/mail/MailDesktopViewController.js
+++ b/src/view/mail/MailDesktopViewController.js
@@ -1373,8 +1373,10 @@ Ext.define("conjoon.cn_mail.view.mail.MailDesktopViewController", {
                         });
                     }
 
-                    md.set("mailAccountId", defInfo.mailAccountId);
-                    md.set("mailFolderId",  defInfo.mailFolderId);
+                    md.set({
+                        "mailAccountId": defInfo.mailAccountId,
+                        "mailFolderId": defInfo.mailFolderId
+                    }, {dirty: false});
                 }
             }
         }

--- a/src/view/mail/message/editor/MessageEditorViewController.js
+++ b/src/view/mail/message/editor/MessageEditorViewController.js
@@ -107,7 +107,7 @@ Ext.define("conjoon.cn_mail.view.mail.message.editor.MessageEditorViewController
             view: view
         });
 
-        view.on("afterrender", me.onMessageEditorAfterrender, me ,{single: true});
+        view.on("afterrender", me.onMessageEditorAfterrender, me, {single: true});
 
         me.ddListener.init();
     },
@@ -143,15 +143,24 @@ Ext.define("conjoon.cn_mail.view.mail.message.editor.MessageEditorViewController
     /**
      * Callback for the "beforeclose"-event of the MessageEditor.
      * Routes to the cn_href of the editor and calls {conjoon.cn_mail.view.mail.message.editor.MessageEditor#showConfirmCloseDialog}
-     * afterwards.
+     * afterwards, only if the MessageDraft of the ViewModel is found to be dirty.
      *
      * @return {Boolean=false} returns false to prevent closing the dialog
+     *
+     * @see {conjoon.cn_mail.view.mail.message.editor.MessageEditorViewModel#isDraftDirty}
      */
     onMailEditorBeforeClose () {
 
         const
             me = this,
+            vm = me.getViewModel(),
             editor = me.getView();
+
+        if (!editor.getMessageDraft() ||
+            !vm.isDraftDirty()
+        ) {
+            return true;
+        }
 
         me.redirectTo(editor.cn_href);
         editor.showConfirmCloseDialog();
@@ -467,16 +476,21 @@ Ext.define("conjoon.cn_mail.view.mail.message.editor.MessageEditorViewController
      * @param {conjoon.cn_mail.view.mail.message.editor.MessageEditor} editor
      * @param {conjoon.cn_mail.model.mail.message.MessageDraft} messageDraft
      */
-    onMailMessageSendComplete: function (editor, messagDraft) {
-        var me   = this,
+    onMailMessageSendComplete (editor, messageDraft) {
+        const
+            me   = this,
             view = me.getView();
 
         /**
          * @i18n
          */
         view.setBusy({msgAction: "Message sent successfully.", progress: 1});
-        me.deferTimers["sendcomplete"] = Ext.Function.defer(
-            view.close, 1000, view);
+
+        me.deferTimers.sendcomplete = Ext.Function.defer(
+            view.close,
+            1000,
+            view
+        );
     },
 
     /**


### PR DESCRIPTION
The confirm dialog is now only shown if changes in the MessageDraft were detected.
Also, immediate closing after sending / deleting a message will not trigger the dialog.

refs conjoon/extjs-app-webmail#112