### PR TITLE
fix: add attachment button in menu does not work

### DIFF
--- a/classic/src/view/mail/message/editor/HtmlEditor.js
+++ b/classic/src/view/mail/message/editor/HtmlEditor.js
@@ -68,6 +68,10 @@ Ext.define("conjoon.cn_mail.view.mail.message.editor.HtmlEditor", {
             }
         });
 
+        let overflowHandler = tbar.getLayout().overflowHandler;
+
+        overflowHandler.addComponentToMenu = me.createOverflowHandlerInterceptor(overflowHandler.addComponentToMenu);
+
         return tbar;
     },
 
@@ -149,6 +153,29 @@ Ext.define("conjoon.cn_mail.view.mail.message.editor.HtmlEditor", {
             "<style type=\"text/css\">",
             "</style></head><body></body></html>"
         ].join("");
+    },
+
+
+    /**
+     * Used to hide the Attachment-Button in the menu that gets rendered with the overflow-handler
+     * of this editor's toolbar.
+     * Creates an interceptor for the passed func that will not call the
+     * passed func if teh component passed to it is of the type
+     * coon.comp.form.field.FileButton.
+     *
+     * @private
+     *
+     * returns function
+     */
+    createOverflowHandlerInterceptor (func) {
+        "use strict";
+
+        return Ext.Function.createInterceptor(func, function (menu, component) {
+            if (component instanceof coon.comp.form.field.FileButton) {
+                return false;
+            }
+        });
     }
+
 
 });

--- a/tests/classic/_issues_/fix/extjs-app-webmail#186.js
+++ b/tests/classic/_issues_/fix/extjs-app-webmail#186.js
@@ -1,0 +1,67 @@
+/**
+ * conjoon
+ * extjs-app-webmail
+ * Copyright (C) 2021 Thorsten Suckow-Homberg https://github.com/conjoon/extjs-app-webmail
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without restriction,
+ * including without limitation the rights to use, copy, modify, merge,
+ * publish, distribute, sublicense, and/or sell copies of the Software,
+ * and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+ * DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+ * OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+ * USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+
+StartTest(async t => {
+
+
+    // +-----------------------------------------
+    // | Tests
+    // +-----------------------------------------
+    t.diag("fix: add attachment button in menu does not work (conjoon/extjs-app-webmail#186)");
+
+
+    t.it("createOverflowHandlerInterceptor()", t => {
+
+        const
+            func = function () { return true;},
+            cmp = Ext.create("conjoon.cn_mail.view.mail.message.editor.HtmlEditor"),
+            cfg = cmp.createOverflowHandlerInterceptor(func);
+
+        t.expect(cfg({}, Ext.create("coon.comp.form.field.FileButton"))).toBe(null);
+        t.expect(cfg({}, {})).toBe(true);
+
+        cmp.destroy();
+    });
+
+
+    t.it("createToolbar()", t => {
+
+        const
+            cmp = Ext.create("conjoon.cn_mail.view.mail.message.editor.HtmlEditor"),
+            interceptSpy = t.spyOn(cmp, "createOverflowHandlerInterceptor").and.callFake(() => "intercepted"),
+            tbar = cmp.createToolbar(),
+            overflowHandler = tbar.getLayout().overflowHandler;
+
+        t.expect(interceptSpy.calls.all()[0].args[0]).toBe(
+            Ext.layout.container.boxOverflow.Menu.prototype.addComponentToMenu
+        );
+        t.expect(overflowHandler.addComponentToMenu).toBe("intercepted");
+
+
+        cmp.destroy();
+    });
+
+});

--- a/tests/groups.config.js
+++ b/tests/groups.config.js
@@ -284,6 +284,9 @@ export default [{
             }, {
                 name: "conjoon/extjs-app-webmail#147",
                 url: "classic/_issues_/fix/extjs-app-webmail%23147.js"
+            }, {
+                name: "conjoon/extjs-app-webmail#186",
+                url: "classic/_issues_/fix/extjs-app-webmail%23186.js"
             }]
         }]
     }, {


### PR DESCRIPTION
the button is now hidden in the menu itself if the menu gets created

refs conjoon/extjs-app-webmail#186